### PR TITLE
delete links to our private GDrive

### DIFF
--- a/docs/antora/modules/ROOT/partials/methodology/key-elements-for-mapping.adoc
+++ b/docs/antora/modules/ROOT/partials/methodology/key-elements-for-mapping.adoc
@@ -21,13 +21,12 @@ To create these mappings, we rely on a number of different resources that were p
 |TED_EXPORT.xsd|The XML Schema defined for the TED XML Notices. Download and extract the versions R2.0.9 and R2.0.8 of the TED XML schema from the links named _Reception: TED eSenders XML schema_ on this page: https://op.europa.eu/en/web/eu-vocabularies/e-procurement/tedschemas[link]
 |TED forms PDFs|PDF files representing the physical forms that are to be completed with the relevant data according to each notice. https://simap.ted.europa.eu/standard-forms-for-public-procurement[link]
 |Deloitte & OP - TED_XML_Mapping|Excel spreadsheets that map elements (fields, sections, etc.) found in the Standard Forms to elements in the eForms. These tables provide the full list of elements and also XPaths to identify the corresponding information TED-XML files.
-https://drive.google.com/drive/folders/120iLgw1owyg5_5S5PAfw95yvz5NMaeCF[link]
-|Ontology_eForms_NEW_Mapping_New Regulation| https://docs.google.com/spreadsheets/d/1KVhJDNP034C6eyYoPTkUvzVEcsseMwcq/edit#gid=188795671[link]
-|Mappings by Everis|Just for reference. Various parts might be out of date. https://drive.google.com/drive/folders/123-ZA3YCdtXBJo3i-YnimMAf7XdBXW72[link]
-|Test data set by Everis|A set of approx. 300 XML files (6 batches of about 50 files each, for the forms F02, F03, F05, F06, F24 and F25) https://drive.google.com/drive/folders/16Qe5x49PbktdQxgY5TU5XnCEd7rxqaCl[link]
-|RDF results by Everis|Just for reference. Various parts might be out of date. https://drive.google.com/drive/folders/1T44VXXQ74_shOtsZta2NbjX4AnYtk14W[link]
+|Ontology_eForms_NEW_Mapping_New Regulation|
+|Mappings by Everis|Just for reference. Various parts might be out of date.
+|Test data set by Everis|A set of approx. 300 XML files (6 batches of about 50 files each, for the forms F02, F03, F05, F06, F24 and F25)
+|RDF results by Everis|Just for reference. Various parts might be out of date.
 |XML Data analysis|Contains various tables, each summarising certain aspects  (e.g. XML elements related to certain fields in the form) of the data extracted from test notice files. https://docs.google.com/spreadsheets/d/1EoHUDDjvx62wXa-LKnDkvolN6dVIeZ_rgm3nNZ91gQo[link]
-|XML Elements to Vocabulary Mapping|https://docs.google.com/spreadsheets/d/13uU5IO_lVfyq8DFed6Wl48gAlHjsnetLnHEotgdWOL4/edit#gid=0[link]
+|XML Elements to Vocabulary Mapping|
 |TED Mappings to ePO terms| https://github.com/OP-TED/ePO/tree/master/analysis_and_design/ted_mappings[link]
 |conventions_report.html|Overview of ePO Terms generated from the UML model. https://github.com/OP-TED/ePO/blob/feature/model-refactoring/analysis_and_design/transformation_output/owl_ontology/conventions_report[conventions_report] (to be checked out and open in a browser)
 |===


### PR DESCRIPTION
Links to our  GDrive were removed. But the descriptions of documenters need to be rewritten